### PR TITLE
Accomodate config to the latest changes in bitnami/nginx

### DIFF
--- a/lemp-compose/docker-compose.yml
+++ b/lemp-compose/docker-compose.yml
@@ -1,13 +1,13 @@
 nginx:
     image: 'bitnami/nginx'
     ports:
-        - '80:80'
+        - '80:8080'
     links:
         - phpfpm
     volumes:
         - ./logs/access.log:/opt/bitnami/nginx/logs/myapp-access.log
         - ./logs/error.log:/opt/bitnami/nginx/logs/myapp-error.log
-        - ./nginx/app.conf:/bitnami/nginx/conf/vhosts/app.conf
+        - ./nginx/app.conf:/opt/bitnami/nginx/conf/vhosts/app.conf
         - ./public:/myapps
 
 phpfpm:


### PR DESCRIPTION
Since version of 1.14 of `bitnami/nginx`, the following changes needed to be made in order for `lemp-compose` config to work:

* Switch to non-privileged port `8080`. Since version 1.14, `bitnami/nginx` runs as a non-privileged user and therefore can't use port `80`, so it uses `8080` by default (see [commit][1]).
* Move `vhosts` directory to `/opt/bitnami/nginx/conf` (see [commit][2]).

[1]: https://github.com/bitnami/bitnami-docker-nginx/commit/bf6dea705a89411f03d9ea7cec6591fe4d00a7f2#diff-e844ede631a4b6a0fa17f1ea1d4b3509R21s://github.com/bitnami/bitnami-docker-nginx/commit/bf6dea705a89411f03d9ea7cec6591fe4d00a7f2#diff-e844ede631a4b6a0fa17f1ea1d4b3509R21
[2]: https://github.com/bitnami/bitnami-docker-nginx/commit/ad39412b4d1bbb982a99eb1e61cb5d25d7756f53